### PR TITLE
Added a std::exception catch all to prevent an uncaught exception

### DIFF
--- a/Dlep.cpp
+++ b/Dlep.cpp
@@ -255,11 +255,17 @@ Dlep::initialize()
         }
     }
     catch (LLDLEP::DlepClient::BadParameterName & bpn)
-    {
+      {
         msg << bpn.what();
         LOG(DLEP_LOG_FATAL, msg);
         notify_initialization_done(false);
-    }
+      }
+    catch (std::exception & exp)
+      {
+        msg << exp.what();
+        LOG(DLEP_LOG_FATAL, msg);
+        notify_initialization_done(false);
+      }
 }
 
 void


### PR DESCRIPTION
Prevent an uncaught exception from propagating outside of the thread causing terminate program abort. Reported by S. Galgano Adjacent Link LLC.