### PR TITLE
Hard coded logger fix

### DIFF
--- a/DlepLogger.cpp
+++ b/DlepLogger.cpp
@@ -6,13 +6,11 @@
 #include "DlepLogger.h"
 #include <time.h>
 #include <ctype.h>
-#include <iostream>
 
 using namespace std;
 using namespace LLDLEP::internal;
 
-DlepLogger::DlepLogger():
-    pstream(&std::cout)
+DlepLogger::DlepLogger()
 {
     this->run_level = DLEP_LOG_INFO;
     //this->run_level = DEBUG;
@@ -21,10 +19,13 @@ DlepLogger::DlepLogger():
     level_name[3] = string("NOTICE: ");
     level_name[4] = string("ERROR: ");
     level_name[5] = string("FATAL: ");
+
+    file_name = "/tmp/dlep_log.txt";
+
+    logfile.open("/tmp/dlep_log.txt");
 }
 
-DlepLogger::DlepLogger(int run_level):
-    pstream(&std::cout)
+DlepLogger::DlepLogger(int run_level)
 {
     if (run_level < DLEP_LOG_DEBUG)
     {
@@ -38,14 +39,12 @@ DlepLogger::DlepLogger(int run_level):
     {
         this->run_level = run_level;
     }
+    logfile.open("dlep_log.txt");
 }
 
 DlepLogger::~DlepLogger()
 {
-    if (logfile.is_open())
-    {
-       logfile.close();
-    }
+    logfile.close();
 }
 
 void
@@ -54,7 +53,7 @@ DlepLogger::log(int level, std::string str)
     boost::mutex::scoped_lock lock(mutex);
     if (level >= run_level)
     {
-        *pstream << level_name[level] << str << endl;
+        logfile << level_name[level] << str << endl;
     }
 }
 
@@ -71,7 +70,7 @@ DlepLogger::log_time(int level, std::string str)
     boost::mutex::scoped_lock lock(mutex);
     if (level >= run_level)
     {
-        *pstream << time_string_get() << level_name[level] << str << endl;
+        logfile << time_string_get() << level_name[level] << str << endl;
     }
 }
 
@@ -102,26 +101,9 @@ DlepLogger::set_run_level(int run_level)
 void
 DlepLogger::set_log_file(const char * name)
 {
-    if (logfile.is_open())
-    {
-       logfile.close();
-    }
+    file_name = name;
+    logfile.close();
     logfile.open(name);
-
-    if (!logfile.fail())
-    {
-        file_name = name;
-        pstream = &logfile;
-    }
-    else
-    {
-      file_name.clear();
-      pstream = &std::cout;
-      ostringstream msg;
-      msg <<  "Unable to open log file: " << name;
-      DlepLogger * logger(this);
-      LOG(DLEP_LOG_ERROR, msg);
-    }
 }
 
 string

--- a/DlepLogger.cpp
+++ b/DlepLogger.cpp
@@ -6,11 +6,13 @@
 #include "DlepLogger.h"
 #include <time.h>
 #include <ctype.h>
+#include <iostream>
 
 using namespace std;
 using namespace LLDLEP::internal;
 
-DlepLogger::DlepLogger()
+DlepLogger::DlepLogger():
+    pstream(&std::cout)
 {
     this->run_level = DLEP_LOG_INFO;
     //this->run_level = DEBUG;
@@ -19,13 +21,10 @@ DlepLogger::DlepLogger()
     level_name[3] = string("NOTICE: ");
     level_name[4] = string("ERROR: ");
     level_name[5] = string("FATAL: ");
-
-    file_name = "/tmp/dlep_log.txt";
-
-    logfile.open("/tmp/dlep_log.txt");
 }
 
-DlepLogger::DlepLogger(int run_level)
+DlepLogger::DlepLogger(int run_level):
+    pstream(&std::cout)
 {
     if (run_level < DLEP_LOG_DEBUG)
     {
@@ -39,12 +38,14 @@ DlepLogger::DlepLogger(int run_level)
     {
         this->run_level = run_level;
     }
-    logfile.open("dlep_log.txt");
 }
 
 DlepLogger::~DlepLogger()
 {
-    logfile.close();
+    if (logfile.is_open())
+    {
+       logfile.close();
+    }
 }
 
 void
@@ -53,7 +54,7 @@ DlepLogger::log(int level, std::string str)
     boost::mutex::scoped_lock lock(mutex);
     if (level >= run_level)
     {
-        logfile << level_name[level] << str << endl;
+        *pstream << level_name[level] << str << endl;
     }
 }
 
@@ -70,7 +71,7 @@ DlepLogger::log_time(int level, std::string str)
     boost::mutex::scoped_lock lock(mutex);
     if (level >= run_level)
     {
-        logfile << time_string_get() << level_name[level] << str << endl;
+        *pstream << time_string_get() << level_name[level] << str << endl;
     }
 }
 
@@ -101,9 +102,26 @@ DlepLogger::set_run_level(int run_level)
 void
 DlepLogger::set_log_file(const char * name)
 {
-    file_name = name;
-    logfile.close();
+    if (logfile.is_open())
+    {
+       logfile.close();
+    }
     logfile.open(name);
+
+    if (!logfile.fail())
+    {
+        file_name = name;
+        pstream = &logfile;
+    }
+    else
+    {
+      file_name.clear();
+      pstream = &std::cout;
+      ostringstream msg;
+      msg <<  "Unable to open log file: " << name;
+      DlepLogger * logger(this);
+      LOG(DLEP_LOG_ERROR, msg);
+    }
 }
 
 string

--- a/DlepLogger.h
+++ b/DlepLogger.h
@@ -60,6 +60,7 @@ private:
     std::string file_name;
     int run_level;
     std::ofstream logfile;
+    std::ostream * pstream;
     std::string time_string_get();
     std::map <int, std::string> level_name;
     boost::mutex mutex;

--- a/DlepLogger.h
+++ b/DlepLogger.h
@@ -60,7 +60,6 @@ private:
     std::string file_name;
     int run_level;
     std::ofstream logfile;
-    std::ostream * pstream;
     std::string time_string_get();
     std::map <int, std::string> level_name;
     boost::mutex mutex;


### PR DESCRIPTION
Modified DlepLogger to no longer open the hard coded /tmp/dlep_log.txt
output file as part of instance construction.

Added a std::ostream pointer member that is set to std::cout until
set_log_file() is called to open a specified output file. Methods
writing output log messages use the std::ostream pointer.

On a failure to open a specified log file, the std::ostream pointer will
default back to std::cout and an error level log message is emitted.
